### PR TITLE
Type strict field values have to override basic fields by annotations

### DIFF
--- a/jam/__init__.py
+++ b/jam/__init__.py
@@ -59,7 +59,7 @@ def is_optional(annotation: typing.Type) -> bool:
 
 def unpack_optional_type(annotation: typing.Union) -> typing.Type:
     """Optional[Type] -> Type"""
-    return [t for t in annotation.__args__ if t is not NoneType][0]
+    return next(t for t in annotation.__args__ if t is not NoneType)
 
 
 def get_marshmallow_field(annotation):

--- a/jam/__init__.py
+++ b/jam/__init__.py
@@ -1,7 +1,6 @@
 import typing as typing
 import logging
 from dataclasses import dataclass
-from typing import get_type_hints
 
 from marshmallow import fields, post_load
 from marshmallow.schema import SchemaMeta as BaseSchemaMeta, BaseSchema, with_metaclass

--- a/jam/tests/test_annotation_mapping.py
+++ b/jam/tests/test_annotation_mapping.py
@@ -2,7 +2,6 @@ import typing as t
 import datetime as dt
 import uuid
 import decimal
-from dataclasses import dataclass
 
 import pytest
 

--- a/jam/tests/test_annotation_mapping.py
+++ b/jam/tests/test_annotation_mapping.py
@@ -2,6 +2,7 @@ import typing as t
 import datetime as dt
 import uuid
 import decimal
+from dataclasses import dataclass
 
 import pytest
 
@@ -61,3 +62,12 @@ def test_optional():
         optional_field: t.Optional[int] = None
 
     assert repr(Response().declared_fields["optional_field"]) == repr(fields.Integer())
+
+
+def test_strict_marshmallow_field():
+    class Response(Schema):
+        basic_field: int
+        email_field: str = fields.Email(required=True)
+
+    assert repr(Response().declared_fields["basic_field"]) == repr(fields.Integer(required=True))
+    assert repr(Response().declared_fields["email_field"]) == repr(fields.Email(required=True))

--- a/project.ini
+++ b/project.ini
@@ -1,5 +1,5 @@
 [project]
 url = https://github.com/nonamenix/marshmallow-jam
-version = 1.0.1
+version = 1.1.0
 name = marshmallow-jam
 description = Some extra sweets for marshmallow.


### PR DESCRIPTION
If you use something like 
```
class Foo(Schema):
    bar: str = fields.Email()
```
The field by annotation will override `Email()` and it will be `String()`
Fixed this